### PR TITLE
feat: add `onRegExpFlags` to `RegExpValidator.Options` and deprecate `onFlags`

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -62,16 +62,26 @@ class RegExpParserState {
         return this._flags
     }
 
-    public onFlags(
+    public onRegExpFlags(
         start: number,
         end: number,
-        global: boolean,
-        ignoreCase: boolean,
-        multiline: boolean,
-        unicode: boolean,
-        sticky: boolean,
-        dotAll: boolean,
-        hasIndices: boolean,
+        {
+            global,
+            ignoreCase,
+            multiline,
+            unicode,
+            sticky,
+            dotAll,
+            hasIndices,
+        }: {
+            global: boolean
+            ignoreCase: boolean
+            multiline: boolean
+            unicode: boolean
+            sticky: boolean
+            dotAll: boolean
+            hasIndices: boolean
+        },
     ): void {
         this._flags = {
             type: "Flags",

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -562,7 +562,7 @@ export class RegExpValidator {
                 this.raise(`Invalid flag '${source[i]}'`)
             }
         }
-        this.onFlags(start, end, {
+        this.onRegExpFlags(start, end, {
             global,
             ignoreCase,
             multiline,
@@ -624,7 +624,7 @@ export class RegExpValidator {
         }
     }
 
-    private onFlags(
+    private onRegExpFlags(
         start: number,
         end: number,
         flags: {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -153,6 +153,31 @@ export namespace RegExpValidator {
          * A function that is called when the validator found flags.
          * @param start The 0-based index of the first character.
          * @param end The next 0-based index of the last character.
+         * @param flags.global `g` flag.
+         * @param flags.ignoreCase `i` flag.
+         * @param flags.multiline `m` flag.
+         * @param flags.unicode `u` flag.
+         * @param flags.sticky `y` flag.
+         * @param flags.dotAll `s` flag.
+         * @param flags.hasIndices `d` flag.
+         */
+        onRegExpFlags?: (
+            start: number,
+            end: number,
+            flags: {
+                global: boolean
+                ignoreCase: boolean
+                multiline: boolean
+                unicode: boolean
+                sticky: boolean
+                dotAll: boolean
+                hasIndices: boolean
+            },
+        ) => void
+        /**
+         * A function that is called when the validator found flags.
+         * @param start The 0-based index of the first character.
+         * @param end The next 0-based index of the last character.
          * @param global `g` flag.
          * @param ignoreCase `i` flag.
          * @param multiline `m` flag.
@@ -160,6 +185,8 @@ export namespace RegExpValidator {
          * @param sticky `y` flag.
          * @param dotAll `s` flag.
          * @param hasIndices `d` flag.
+         *
+         * @deprecated Use `onRegExpFlags` instead.
          */
         onFlags?: (
             start: number,
@@ -535,9 +562,7 @@ export class RegExpValidator {
                 this.raise(`Invalid flag '${source[i]}'`)
             }
         }
-        this.onFlags(
-            start,
-            end,
+        this.onFlags(start, end, {
             global,
             ignoreCase,
             multiline,
@@ -545,7 +570,7 @@ export class RegExpValidator {
             sticky,
             dotAll,
             hasIndices,
-        )
+        })
     }
 
     /**
@@ -602,25 +627,31 @@ export class RegExpValidator {
     private onFlags(
         start: number,
         end: number,
-        global: boolean,
-        ignoreCase: boolean,
-        multiline: boolean,
-        unicode: boolean,
-        sticky: boolean,
-        dotAll: boolean,
-        hasIndices: boolean,
+        flags: {
+            global: boolean
+            ignoreCase: boolean
+            multiline: boolean
+            unicode: boolean
+            sticky: boolean
+            dotAll: boolean
+            hasIndices: boolean
+        },
     ): void {
+        if (this._options.onRegExpFlags) {
+            this._options.onRegExpFlags(start, end, flags)
+        }
+        // Backward compatibility
         if (this._options.onFlags) {
             this._options.onFlags(
                 start,
                 end,
-                global,
-                ignoreCase,
-                multiline,
-                unicode,
-                sticky,
-                dotAll,
-                hasIndices,
+                flags.global,
+                flags.ignoreCase,
+                flags.multiline,
+                flags.unicode,
+                flags.sticky,
+                flags.dotAll,
+                flags.hasIndices,
             )
         }
     }


### PR DESCRIPTION
This PR deprecates `onFlags` in `RegExpValidator.Options` and adds `onRegExpFlags` option instead.

The current `RegExpValidator.Options` `onFlags` has too many arguments because it has as many arguments as the number of flags. (And we know that more flags will be added in the future. e.g. https://github.com/tc39/proposal-regexp-v-flag)
This has always been a warning to the ESLint we use.

```
/home/runner/work/regexpp/regexpp/src/parser.ts
Warning:   65:5  warning  Method 'onFlags' has too many parameters (9). Maximum allowed is 8  max-params

/home/runner/work/regexpp/regexpp/src/validator.ts
Warning:   602:5  warning  Method 'onFlags' has too many parameters (9). Maximum allowed is 8  max-params
```

So instead of giving each flag as multiple arguments, I think it's better to have a single object with the flags information.

However, changing `onFlags` would be a breaking change, so I think it makes sense to leave `onFlags` as a deprecated option and introduce a new `onRegExpFlags`. The name of `onRegExpFlags` was named with reference to `RegularExpressionFlags` used in ES specifications.

https://tc39.es/ecma262/#prod-RegularExpressionFlags

