### PR TITLE
chore: Include documentation in `index.d.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build": "run-s build:*",
     "build:tsc": "tsc --module es2015",
     "build:rollup": "rollup -c",
-    "build:dts": "dts-bundle --name @eslint-community/regexpp --main .temp/index.d.ts --out ../index.d.ts",
+    "build:dts": "npm run -s build:tsc -- --removeComments false && dts-bundle --name @eslint-community/regexpp --main .temp/index.d.ts --out ../index.d.ts && prettier --write index.d.ts",
     "clean": "rimraf .temp index.*",
     "lint": "eslint . --ext .ts",
     "test": "nyc _mocha \"test/*.ts\" --reporter dot --timeout 10000",


### PR DESCRIPTION
Fixes https://github.com/mysticatea/regexpp/issues/19

This PR includes the JSDoc comments for public API parts in `index.d.ts`. Since `dts-bundle` doesn't format comments, I used prettier to format `index.d.ts`, so it's nicer to read. 

Note that the other build files (e.g. `index.mjs`) are not affected by this PR.

<details>
<summary>Example</summary>

```ts
// Generated by dts-bundle v0.7.3

declare module "@eslint-community/regexpp" {
  import * as AST from "@eslint-community/regexpp/ast";
  import { RegExpParser } from "@eslint-community/regexpp/parser";
  import { RegExpValidator } from "@eslint-community/regexpp/validator";
  import { RegExpVisitor } from "@eslint-community/regexpp/visitor";
  export { AST, RegExpParser, RegExpValidator };
  /**
   * Parse a given regular expression literal then make AST object.
   * @param source The source code to parse.
   * @param options The options to parse.
   * @returns The AST of the regular expression.
   */
  export function parseRegExpLiteral(
    source: RegExp | string,
    options?: RegExpParser.Options
  ): AST.RegExpLiteral;
  /**
   * Validate a given regular expression literal.
   * @param source The source code to validate.
   * @param options The options to validate.
   */
  export function validateRegExpLiteral(
    source: string,
    options?: RegExpValidator.Options
  ): void;
  export function visitRegExpAST(
    node: AST.Node,
    handlers: RegExpVisitor.Handlers
  ): void;
}
```

</details>



