### PR TITLE
fix: wrong syntax error message when using `RegExpValidator#validatePattern` and `RegExpValidator#validateFlags`.

### DIFF
--- a/src/regexp-syntax-error.ts
+++ b/src/regexp-syntax-error.ts
@@ -1,22 +1,27 @@
+import type { RegExpValidatorSourceContext } from "./validator"
+
 export class RegExpSyntaxError extends SyntaxError {
     public index: number
 
     public constructor(
-        source: string,
+        srcCtx: RegExpValidatorSourceContext,
         flags: { unicode: boolean; unicodeSets: boolean },
         index: number,
         message: string,
     ) {
-        /*eslint-disable no-param-reassign */
-        if (source) {
-            if (!source.startsWith("/")) {
-                source = `/${source}/${flags.unicode ? "u" : ""}${
-                    flags.unicodeSets ? "v" : ""
-                }`
+        let source = ""
+        if (srcCtx.kind === "literal") {
+            const literal = srcCtx.source.slice(srcCtx.start, srcCtx.end)
+            if (literal) {
+                source = `: ${literal}`
             }
-            source = `: ${source}`
+        } else if (srcCtx.kind === "pattern") {
+            const pattern = srcCtx.source.slice(srcCtx.start, srcCtx.end)
+            const flagsText = `${flags.unicode ? "u" : ""}${
+                flags.unicodeSets ? "v" : ""
+            }`
+            source = `: /${pattern}/${flagsText}`
         }
-        /*eslint-enable no-param-reassign */
 
         super(`Invalid regular expression${source}: ${message}`)
         this.index = index

--- a/test/validate-error.ts
+++ b/test/validate-error.ts
@@ -1,0 +1,176 @@
+import assert from "assert"
+import { RegExpValidator } from "../src/index"
+import type { RegExpSyntaxError } from "../src/regexp-syntax-error"
+
+const validator = new RegExpValidator()
+
+function getErrorForPattern(
+    source: string,
+    start: number,
+    end: number,
+    flags: {
+        unicode?: boolean
+        unicodeSets?: boolean
+    },
+): RegExpSyntaxError {
+    try {
+        validator.validatePattern(source, start, end, flags)
+    } catch (err) {
+        const error = err as RegExpSyntaxError
+        return error
+    }
+    return assert.fail("Should fail, but succeeded.")
+}
+
+function getErrorForFlags(
+    source: string,
+    start: number,
+    end: number,
+): RegExpSyntaxError {
+    try {
+        validator.validateFlags(source, start, end)
+    } catch (err) {
+        const error = err as RegExpSyntaxError
+        return error
+    }
+    return assert.fail("Should fail, but succeeded.")
+}
+
+function getErrorForLiteral(
+    source: string,
+    start: number,
+    end: number,
+): RegExpSyntaxError {
+    try {
+        validator.validateLiteral(source, start, end)
+    } catch (err) {
+        const error = err as RegExpSyntaxError
+        return error
+    }
+    return assert.fail("Should fail, but succeeded.")
+}
+
+describe("RegExpValidator#validatePattern error:", () => {
+    for (const test of [
+        {
+            source: "abcd",
+            start: 0,
+            end: 2,
+            flags: { unicode: true, unicodeSets: true },
+            error: {
+                message:
+                    "Invalid regular expression: /ab/uv: Invalid regular expression flags",
+                index: 3,
+            },
+        },
+        {
+            source: "[A]",
+            start: 0,
+            end: 2,
+            flags: { unicode: true, unicodeSets: false },
+            error: {
+                message:
+                    "Invalid regular expression: /[A/u: Unterminated character class",
+                index: 2,
+            },
+        },
+        {
+            source: "[[A]]",
+            start: 0,
+            end: 4,
+            flags: { unicode: false, unicodeSets: true },
+            error: {
+                message:
+                    "Invalid regular expression: /[[A]/v: Unterminated character class",
+                index: 4,
+            },
+        },
+        {
+            source: " /[[A]/v ",
+            start: 2,
+            end: 6,
+            flags: { unicode: false, unicodeSets: true },
+            error: {
+                message:
+                    "Invalid regular expression: /[[A]/v: Unterminated character class",
+                index: 6,
+            },
+        },
+    ]) {
+        it(`${JSON.stringify(test)} should throw syntax error.`, () => {
+            const error = getErrorForPattern(
+                test.source,
+                test.start,
+                test.end,
+                test.flags,
+            )
+            assert.deepStrictEqual(
+                { message: error.message, index: error.index },
+                test.error,
+            )
+        })
+    }
+})
+
+describe("RegExpValidator#validateFlags error:", () => {
+    for (const test of [
+        {
+            source: "abcd",
+            start: 0,
+            end: 2,
+            error: {
+                message: "Invalid regular expression: Invalid flag 'a'",
+                index: 0,
+            },
+        },
+        {
+            source: "dd",
+            start: 0,
+            end: 2,
+            error: {
+                message: "Invalid regular expression: Duplicated flag 'd'",
+                index: 0,
+            },
+        },
+        {
+            source: "/a/dd",
+            start: 3,
+            end: 5,
+            error: {
+                message: "Invalid regular expression: Duplicated flag 'd'",
+                index: 3,
+            },
+        },
+    ]) {
+        it(`${JSON.stringify(test)} should throw syntax error.`, () => {
+            const error = getErrorForFlags(test.source, test.start, test.end)
+            assert.deepStrictEqual(
+                { message: error.message, index: error.index },
+                test.error,
+            )
+        })
+    }
+})
+
+describe("RegExpValidator#validateLiteral error:", () => {
+    for (const test of [
+        {
+            source: " /[/ ",
+            start: 1,
+            end: 4,
+            error: {
+                message:
+                    "Invalid regular expression: /[/: Unterminated character class",
+                index: 4,
+            },
+        },
+    ]) {
+        it(`${JSON.stringify(test)} should throw syntax error.`, () => {
+            const error = getErrorForLiteral(test.source, test.start, test.end)
+            assert.deepStrictEqual(
+                { message: error.message, index: error.index },
+                test.error,
+            )
+        })
+    }
+})


### PR DESCRIPTION
fixes #112