### PR TITLE
feat: Fixed variants of `ClassRangesCharacterClassElement`

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -59,8 +59,8 @@ export type CharacterClassElement =
 export type ClassRangesCharacterClassElement =
     | Character
     | CharacterClassRange
+    | CharacterUnicodePropertyCharacterSet
     | EscapeCharacterSet
-    | UnicodePropertyCharacterSet
 export type UnicodeSetsCharacterClassElement =
     | Character
     | CharacterClassRange

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -444,7 +444,15 @@ class RegExpParserState {
                   negate,
                   strings: false,
               }
-        parent.elements.push(node)
+
+        if (node.strings) {
+            if (parent.type === "CharacterClass" && !parent.unicodeSets) {
+                throw new Error("UnknownError")
+            }
+            parent.elements.push(node)
+        } else {
+            parent.elements.push(node)
+        }
     }
 
     public onCharacter(start: number, end: number, value: number): void {


### PR DESCRIPTION
fixes #121

This PR changes the type of `ClassRangesCharacterClassElement` to not include properties of strings. See #121 for details.

The new type caused a type error in the `RegExpParserState#onUnicodePropertyCharacterSet`. TypeScript was unable to prove that no `StringsUnicodePropertyCharacterSet` was added to a `ClassRangesCharacterClass`. So I changed the parser to fix this type error. I intentionally did not use type casts, so that TypeScript can statically prove that the parser creates a correct AST.