### PR TITLE
feat: improve types to fix `parent` type of string Unicode properties

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -330,6 +330,12 @@ export interface CharacterUnicodePropertyCharacterSet
 /** StringsUnicodePropertyCharacterSet is Unicode property escape with property of strings. */
 export interface StringsUnicodePropertyCharacterSet
     extends BaseUnicodePropertyCharacterSet {
+    parent:
+        | Alternative
+        | ClassIntersection
+        | ClassSubtraction
+        | Quantifier
+        | UnicodeSetsCharacterClass
     strings: true
     value: null
     negate: false

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -434,21 +434,9 @@ class RegExpParserState {
                 throw new Error("UnknownError")
             }
 
-            parent.elements.push({
-                ...base,
-                parent,
-                strings,
-                value,
-                negate,
-            })
+            parent.elements.push({ ...base, parent, strings, value, negate })
         } else {
-            parent.elements.push({
-                ...base,
-                parent,
-                strings,
-                value,
-                negate,
-            })
+            parent.elements.push({ ...base, parent, strings, value, negate })
         }
     }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,7 +16,6 @@ import type {
     ClassSubtraction,
     UnicodeSetsCharacterClassElement,
     ClassSetOperand,
-    UnicodePropertyCharacterSet,
     UnicodeSetsCharacterClass,
     ExpressionCharacterClass,
     StringAlternative,
@@ -413,45 +412,43 @@ class RegExpParserState {
         strings: boolean,
     ): void {
         const parent = this._node
-        if (
-            (parent.type !== "Alternative" &&
-                parent.type !== "CharacterClass") ||
-            (strings && (negate || value))
-        ) {
+        if (parent.type !== "Alternative" && parent.type !== "CharacterClass") {
             throw new Error("UnknownError")
         }
 
         const base = {
             type: "CharacterSet",
-            parent,
             start,
             end,
             raw: this.source.slice(start, end),
             kind,
-            strings,
             key,
         } as const
-        const node: UnicodePropertyCharacterSet = strings
-            ? {
-                  ...base,
-                  value: null,
-                  negate: false,
-                  strings: true,
-              }
-            : {
-                  ...base,
-                  value,
-                  negate,
-                  strings: false,
-              }
 
-        if (node.strings) {
-            if (parent.type === "CharacterClass" && !parent.unicodeSets) {
+        if (strings) {
+            if (
+                (parent.type === "CharacterClass" && !parent.unicodeSets) ||
+                negate ||
+                value !== null
+            ) {
                 throw new Error("UnknownError")
             }
-            parent.elements.push(node)
+
+            parent.elements.push({
+                ...base,
+                parent,
+                strings,
+                value,
+                negate,
+            })
         } else {
-            parent.elements.push(node)
+            parent.elements.push({
+                ...base,
+                parent,
+                strings,
+                value,
+                negate,
+            })
         }
     }
 


### PR DESCRIPTION
`StringsUnicodePropertyCharacterSet` allowed `ClassRangesCharacterClass` as their parent, which is not correct (see #123). This PR changes the `parent` type of `StringsUnicodePropertyCharacterSet` to remove ``ClassRangesCharacterClass``.

I also had to change the parser to get rid of type errors. Since we now have to prove that `parent` has a certain type, I had to change the code for `onUnicodePropertyCharacterSet` again. While having `parent.elements.push({ ...base, parent, strings, value, negate })` twice is code duplication, it's necessary for TS to prove that the types check out.

---

About why I used ``parent.elements.push({ ...base, parent, strings, value, negate })`` instead of `parent.elements.push({ ...base, parent, strings, value: null, negate: false })` in the `if (strings)` branch. By using the `value` and `negate` parameters instead of assigning the object properties a constant, TS forces us to validate the values of those 2 parameters.

This strict validation even unearthed a super minor bug. Calling `onUnicodePropertyCharacterSet` with a value of `""` (empty string) for string properties was previously accepted as valid (see `(strings && (negate || value))`). Now that TS forces us to validate `value` correctly, this is no longer the case.