### PR TITLE
chore: fix update script to revert code format

### DIFF
--- a/scripts/update-unicode-properties.ts
+++ b/scripts/update-unicode-properties.ts
@@ -269,9 +269,9 @@ function makeClassDeclarationCode(versions: string[]): string {
     const fields = versions
         .map(
             (v) =>
-                `private _raw${v}: string\nprivate _set${v}: Set<string> | undefined`,
+                `private _raw${v}: string\n\nprivate _set${v}: Set<string> | undefined`,
         )
-        .join("\n")
+        .join("\n\n")
     const parameters = versions.map((v) => `raw${v}: string`).join(", ")
     const init = versions.map((v) => `this._raw${v} = raw${v}`).join("\n")
     const getters = versions
@@ -279,14 +279,16 @@ function makeClassDeclarationCode(versions: string[]): string {
             (v) =>
                 `public get es${v}(): Set<string> { return this._set${v} ?? (this._set${v} = new Set(this._raw${v}.split(" "))) }`,
         )
-        .join("\n")
+        .join("\n\n")
 
     return `
         class DataSet {
             ${fields}
+
             public constructor(${parameters}) {
                 ${init}
             }
+
             ${getters}
         }
     `


### PR DESCRIPTION
There is an error in the update check CI, but this seems to be caused by a change in the format. This PR fixes the formatting issue.

https://github.com/eslint-community/regexpp/actions/runs/7770451361