### PR TITLE
ci: lock down third party action

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm install
       - name: Update
         run: npm run update:unicode
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           commit-message: "fix: updates unicode resource with latest"
           branch: update-unicode-resource
@@ -44,7 +44,7 @@ jobs:
         run: npm install
       - name: Update
         run: npm run update:test262:extract
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           commit-message: "test: updates test cases extracted from test262"
           branch: update-test262


### PR DESCRIPTION
Its best practice to lock down third party actions to hash, since the tags are not immutable.

Follow up to #193