### PR TITLE
chore: update Node.js version to lts/* for release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,7 @@ jobs:
       - name: ⎔ Setup Node
         uses: actions/setup-node@v4
         with:
-          # node 24 is required for semantic-release@v25.
-          # However, `lts/*` may point to v24 in the near future, so it's better to use `lts/*`.
-          node-version: 24
+          node-version: lts/*
 
       # npm 11.5.1 or later is required so update to latest to be sure
       - name: Update npm


### PR DESCRIPTION
This PR changes the release job to use Node.js `lts/*`.

We didn't need to use node 24 😓 :
https://github.com/eslint-community/regexpp/issues/216#issuecomment-3432541987